### PR TITLE
[FIX] Date TimeZone 수정

### DIFF
--- a/app/src/main/java/co/kr/woowahan_repo/domain/GithubApiDateFormat.kt
+++ b/app/src/main/java/co/kr/woowahan_repo/domain/GithubApiDateFormat.kt
@@ -1,10 +1,13 @@
 package co.kr.woowahan_repo.domain
 
 import java.text.SimpleDateFormat
+import java.util.*
 
 class GithubApiDateFormat {
     private val githubDateFormatString = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-    private val formatter = SimpleDateFormat(githubDateFormatString)
+    private val formatter = SimpleDateFormat(githubDateFormatString).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
 
     fun getSimpleDateFormat(): SimpleDateFormat {
         return formatter


### PR DESCRIPTION
Github Date Format 이 +9시간 되는 문제 수정 
- Github Date Format Timezone UTC 설정

## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #61 
## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] Github date format의 timezone을 utc로 수정

close #61 