### PR TITLE
[FIX] 프로필 이미지 캐시처리 누락된 코드 수정

### DIFF
--- a/app/src/main/java/co/kr/woowahan_repo/data/datasource/WoowahanSharedPreferences.kt
+++ b/app/src/main/java/co/kr/woowahan_repo/data/datasource/WoowahanSharedPreferences.kt
@@ -2,13 +2,14 @@ package co.kr.woowahan_repo.data.datasource
 
 import android.content.Context
 import androidx.core.content.edit
+import co.kr.woowahan_repo.domain.datasource.GithubProfileDataSource
 import co.kr.woowahan_repo.domain.datasource.GithubTokenDataSource
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class WoowahanSharedPreferences @Inject constructor(
     @ApplicationContext private val context: Context
-): GithubTokenDataSource {
+): GithubTokenDataSource, GithubProfileDataSource {
     companion object {
         private const val spName = "WOOWAHAN"
     }
@@ -18,10 +19,20 @@ class WoowahanSharedPreferences @Inject constructor(
         get() = sp.getString("github_token", null) ?: ""
         set(value) = sp.edit { putString("github_token", value) }
 
+    private var githubProfileUrl: String
+        get() = sp.getString("github_profile_url", null) ?: ""
+        set(value) = sp.edit { putString("github_profile_url", value) }
+
     override fun updateToken(token: String) {
         githubToken = token
     }
 
     override fun fetchToken(): String = githubToken
+
+    override fun updateProfileUrl(url: String) {
+        githubProfileUrl = url
+    }
+
+    override fun fetchProfileUrl(): String = githubProfileUrl
 
 }

--- a/app/src/main/java/co/kr/woowahan_repo/data/repository/GithubProfileRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_repo/data/repository/GithubProfileRepositoryImpl.kt
@@ -2,6 +2,7 @@ package co.kr.woowahan_repo.data.repository
 
 import co.kr.woowahan_repo.data.service.GithubProfileService
 import co.kr.woowahan_repo.data.service.GithubUsersRepositoriesService
+import co.kr.woowahan_repo.domain.datasource.GithubProfileDataSource
 import co.kr.woowahan_repo.domain.model.GithubProfileModel
 import co.kr.woowahan_repo.domain.repository.GithubProfileRepository
 import timber.log.Timber
@@ -9,20 +10,20 @@ import javax.inject.Inject
 
 class GithubProfileRepositoryImpl @Inject constructor(
     private val githubProfileService: GithubProfileService,
-    private val githubUsersRepositoriesService: GithubUsersRepositoriesService
+    private val githubUsersRepositoriesService: GithubUsersRepositoriesService,
+    private val githubProfileDataSource: GithubProfileDataSource
 ): GithubProfileRepository {
-    private var cacheProfileUrl: String? = null
 
     override suspend fun fetchProfileUrl(): Result<String> {
-        Timber.d("fetchProfileUrl cache[$cacheProfileUrl]")
-        return if(cacheProfileUrl.isNullOrBlank()){
+        Timber.d("fetchProfileUrl cache[${githubProfileDataSource.fetchProfileUrl()}]")
+        return if(githubProfileDataSource.fetchProfileUrl().isBlank()){
             kotlin.runCatching {
                 githubProfileService.fetchGithubProfile().toProfileUrl()
             }.onSuccess {
-                cacheProfileUrl = it
+                githubProfileDataSource.updateProfileUrl(it)
             }
         }else
-            Result.success(cacheProfileUrl!!)
+            Result.success(githubProfileDataSource.fetchProfileUrl())
     }
 
     override suspend fun fetchProfile(): Result<GithubProfileModel> {
@@ -32,6 +33,9 @@ class GithubProfileRepositoryImpl @Inject constructor(
                 starCount = githubUsersRepositoriesService.fetchUsersRepositories(
                     res.reposUrl
                 ).sumOf { it.stargazersCount }
+            }.also {
+                githubProfileDataSource.updateProfileUrl(it.profileImage)
+                Timber.d("fetchProfileUrl cache refresh[${githubProfileDataSource.fetchProfileUrl()}]")
             }
         }
     }

--- a/app/src/main/java/co/kr/woowahan_repo/di/DataSourceModule.kt
+++ b/app/src/main/java/co/kr/woowahan_repo/di/DataSourceModule.kt
@@ -1,6 +1,7 @@
 package co.kr.woowahan_repo.di
 
 import co.kr.woowahan_repo.data.datasource.WoowahanSharedPreferences
+import co.kr.woowahan_repo.domain.datasource.GithubProfileDataSource
 import co.kr.woowahan_repo.domain.datasource.GithubTokenDataSource
 import dagger.Binds
 import dagger.Module
@@ -13,5 +14,8 @@ abstract class DataSourceModule {
 
     @Binds
     abstract fun bindGithubTokenDataSource(impl: WoowahanSharedPreferences): GithubTokenDataSource
+    
+    @Binds
+    abstract fun bindGithubProfileSource(impl: WoowahanSharedPreferences): GithubProfileDataSource
 
 }

--- a/app/src/main/java/co/kr/woowahan_repo/domain/datasource/GithubProfileDataSource.kt
+++ b/app/src/main/java/co/kr/woowahan_repo/domain/datasource/GithubProfileDataSource.kt
@@ -1,0 +1,6 @@
+package co.kr.woowahan_repo.domain.datasource
+
+interface GithubProfileDataSource {
+    fun updateProfileUrl(url: String)
+    fun fetchProfileUrl() : String
+}


### PR DESCRIPTION
-  Profile Image Cache 처리가 누락된 코드 수정
 - 수정을 진행하다보니, 어차피 repo 구현체가 singletone이 아니게 처리를 하였기때문에, 캐시된 이미지가 main, profile에서 공유되지 않는 문제가 있음을 파악하였고, data source를 추가하여 리소스가 공유되도록 처리하였다

## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #64 
## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] profile repository 구현체 에서 프로필 이미지 캐시처리 코드가 누락된 것 수정

close -#64