### PR TITLE
[FIX][Service-Locator] 프로필 이미지 캐시처리 누락된 코드 수정

### DIFF
--- a/app/src/main/java/co/kr/woowahan_repo/data/datasource/GithubProfileDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_repo/data/datasource/GithubProfileDataSourceImpl.kt
@@ -1,0 +1,22 @@
+package co.kr.woowahan_repo.data.datasource
+
+import co.kr.woowahan_repo.domain.datasource.GithubProfileDataSource
+
+class GithubProfileDataSourceImpl private constructor(): GithubProfileDataSource {
+    companion object {
+        private var instance: GithubProfileDataSourceImpl? = null
+        fun getInstance(): GithubProfileDataSourceImpl {
+            if(instance == null)
+                instance = GithubProfileDataSourceImpl()
+            return instance!!
+        }
+    }
+    private var profileUrl: String? = null
+
+    override fun updateProfileUrl(url: String) {
+        profileUrl = url
+    }
+
+    override fun fetchProfileUrl(): String = profileUrl ?: ""
+
+}

--- a/app/src/main/java/co/kr/woowahan_repo/di/ServiceLocator.kt
+++ b/app/src/main/java/co/kr/woowahan_repo/di/ServiceLocator.kt
@@ -4,9 +4,11 @@ import co.kr.woowahan_repo.BuildConfig
 import co.kr.woowahan_repo.application.WoowahanRepoApplication
 import co.kr.woowahan_repo.data.datasource.WoowahanSharedPreferences
 import co.kr.woowahan_repo.data.api.interceptor.AuthInterceptor
+import co.kr.woowahan_repo.data.datasource.GithubProfileDataSourceImpl
 import co.kr.woowahan_repo.data.repository.*
 import co.kr.woowahan_repo.data.service.*
 import co.kr.woowahan_repo.domain.GithubApiDateFormat
+import co.kr.woowahan_repo.domain.datasource.GithubProfileDataSource
 import co.kr.woowahan_repo.domain.datasource.GithubTokenDataSource
 import co.kr.woowahan_repo.domain.repository.*
 import okhttp3.OkHttpClient
@@ -18,10 +20,17 @@ object ServiceLocator {
 
     fun provideGithubApiDateFormat(): GithubApiDateFormat = GithubApiDateFormat.getInstance()
 
+    /**
+     * data source
+     */
     fun provideGithubTokenDataSource(): GithubTokenDataSource = WoowahanSharedPreferences(
         WoowahanRepoApplication.instance
     )
+    private fun provideGithubProfileDataSource(): GithubProfileDataSource = GithubProfileDataSourceImpl.getInstance()
 
+    /**
+     * retrofit
+     */
     private fun getAuthInterceptor() = AuthInterceptor(provideGithubTokenDataSource().fetchToken())
 
     private fun getOAuthClient() = OkHttpClient.Builder()
@@ -105,7 +114,8 @@ object ServiceLocator {
     fun provideGithubProfileRepository(): GithubProfileRepository =
         GithubProfileRepositoryImpl(
             provideGithubProfileService(),
-            provideGithubUsersRepositoriesService()
+            provideGithubUsersRepositoriesService(),
+            provideGithubProfileDataSource()
         )
 
 }

--- a/app/src/main/java/co/kr/woowahan_repo/domain/datasource/GithubProfileDataSource.kt
+++ b/app/src/main/java/co/kr/woowahan_repo/domain/datasource/GithubProfileDataSource.kt
@@ -1,0 +1,6 @@
+package co.kr.woowahan_repo.domain.datasource
+
+interface GithubProfileDataSource {
+    fun updateProfileUrl(url: String)
+    fun fetchProfileUrl() : String
+}


### PR DESCRIPTION
 - 수정을 진행하다보니, 어차피 repo 구현체가 singletone이 아니게 처리를 하였기때문에, 캐시된 이미지가 main, profile에서 공유되지 않는 문제가 있음을 파악하였고, data source를 추가하여 리소스가 공유되도록 처리하였다
 - data source 구현체는 리소스 공유를 위해 싱글톤으로 설정

## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #74 
## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] profile repository 구현체 에서 프로필 이미지 캐시처리 코드가 누락된 것 수정

close #74 